### PR TITLE
Fix SSLCertificates::ConvertDER

### DIFF
--- a/src/SSLCertificates.cpp
+++ b/src/SSLCertificates.cpp
@@ -86,9 +86,10 @@ vDER SSLCertificates::ConvertX509Vector(const vX509 & x509Vect) {
 X509* SSLCertificates::ConvertDER(const DER & der) {
 	//Assuming openssl 0.9.7 or higher
 	X509 * x509 = NULL;
-
+	
 	unsigned char * buf = der.data;
-	x509 = d2i_X509(NULL, const_cast<const unsigned char **>(&buf), der.len);
+
+	x509 = d2i_X509(NULL, (const unsigned char **)&buf, der.len);
 
 	return x509;
 }


### PR DESCRIPTION
Use temporary buffer according to https://www.openssl.org/docs/crypto/d2i_X509.html#WARNINGS to avoid SEGFAULT at OPENSSL_free.
