### PR TITLE
Fix "Unknown authentication method" being returned for some servers

### DIFF
--- a/src/FTPClientWrapperSSH.cpp
+++ b/src/FTPClientWrapperSSH.cpp
@@ -479,6 +479,8 @@ int FTPClientWrapperSSH::authenticate(ssh_session session) {
 	int authres = 0;
 
 	authres = ssh_userauth_none(session, NULL);
+	if (authres == SSH_AUTH_AGAIN)
+		authres = ssh_userauth_none(session, NULL);
 	if (authres == SSH_AUTH_ERROR) {
 		OutErr("[SFTP] Error during authentication: %s", ssh_get_error(session));
 		return -1;


### PR DESCRIPTION
This is done by retrying ssh_userauth_none() in case it returns
SSH_AUTH_AGAIN the first time, as suggested in
http://www.libssh.org/archive/libssh/2014-07/0000012.html

Signed-off-by: tbeu <tc@tbeu.de>